### PR TITLE
Update strings.xml

### DIFF
--- a/German/main/MiuiScanner.apk/res/values-de/strings.xml
+++ b/German/main/MiuiScanner.apk/res/values-de/strings.xml
@@ -211,9 +211,9 @@
   <string name="feedback_description_save_photo">Bild oder Video wurde nicht gespeichet</string>
   <string name="feedback_phone">Kontaktinfo (optional)</string>
   <string name="filename_cannot_beempty">Dateiname darf nicht leer sein</string>
-  <string name="flash_close">Aus</string>
+  <string name="flash_close">Ausschalten</string>
   <string name="flash_lable">Blitz</string>
-  <string name="flash_open">An</string>
+  <string name="flash_open">Einschalten</string>
   <string name="flight_mode_connecting_to_wifi">WLAN manuell einschalten, wenn der Flugmodus an ist</string>
   <string name="fmt_chinese_date">d.M.</string>
   <string name="fmt_date_day">d.</string>


### PR DESCRIPTION
Vielleicht doch besser "Einschalten"/"Ausschalten" oder "Blitz ein"/"Blitz aus" oder sogar "Blitz einschalten"/"Blitz ausschalten"? Weil Ein/Aus sind "nur" Zustände und keine Aktionen und sonst würde hier Vieles mit Einschalten/Ausschalten übersetzt, was konsistenter wäre. Aber ich würde wenn dann Ein statt An verwenden, sehe fast nie "An" bei technischen Geräten, klingt irgendwie umgangssprachlich.