### PR TITLE
An/Aus vertauscht

### DIFF
--- a/German/main/AuthManager.apk/res/values-de/strings.xml
+++ b/German/main/AuthManager.apk/res/values-de/strings.xml
@@ -330,8 +330,8 @@
   <string name="permission_warning_template_ask">%1$s die folgenden Berechtigungen erteilen?</string>
   <string name="permisson_reject_notice_toast_text2">hat keine Berechtigung, %1$s.</string>
   <string name="pp_privacy_lab_operator_introduction">Achtung</string>
-  <string name="real_location_off">Ungefährer Standort ist aus</string>
-  <string name="real_location_on">Ungefährer Standort ist an</string>
+  <string name="real_location_off">Genauer Standort ist aus</string>
+  <string name="real_location_on">Genauer Standort ist an</string>
   <string name="saturday">Samstag</string>
   <string name="saturday_short">Sa</string>
   <string name="saturday_shortest">S</string>


### PR DESCRIPTION
Eigtl war nur Ungefährer Standort ist aus/an vertauscht, aber das Wort Ungefähr in Genauer Standort zu ändern ist eine viel bessere Übersetzung, falls aber das englische Original gewünscht ist muss ist nur aus mit an vice versa zu tauschen.