### PR TITLE
App-Sperre aktiv

### DIFF
--- a/German/main/MiuiHome.apk/res/values-de/strings.xml
+++ b/German/main/MiuiHome.apk/res/values-de/strings.xml
@@ -760,7 +760,7 @@
   <string name="switch_screen_button_order_desc">Zurück- und Menütaste spiegeln</string>
   <string name="system_shortcuts_more_operation">App-Info</string>
   <string name="system_shortcuts_remove">Entfernen</string>
-  <string name="task_access_locked_app_msg">App-Sperre ausgeschaltet</string>
+  <string name="task_access_locked_app_msg">App-Sperre aktiv</string>
   <string name="the_anniversary_of_lifting_martial_law">Jahrestag der Aufhebung des Kriegsrechts</string>
   <string name="the_anti_aggression_day">Antiaggressionstag</string>
   <string name="the_arbor_day">Tag des Baumes</string>


### PR DESCRIPTION
Müsste eingeschaltet statt ausgeschaltet sein, aber "App-Sperre aktiv" klingt besser, je nach Geschmack.